### PR TITLE
added parent(callback) to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The following methods must be used with a callback. The callback method will be 
 
 * selfAndAncestors(callback)
 
+* parent(callback)
+
 * ancestors(callback)
 
 * selfAndChildren(callback)


### PR DESCRIPTION
I was in need of a function that returned the parent of a node, and didn't see it in the README but I saw it in the source. So now it is in the README :smile: 
