### PR TITLE
converting methods to follow mongoose params model

### DIFF
--- a/lib/nested_set.js
+++ b/lib/nested_set.js
@@ -168,82 +168,241 @@ var NestedSetPlugin = function(schema, options) {
   // returns the parent node
   schema.method('parent', function(callback) {
     var self = this;
-    self.constructor.findOne({_id: self.parentId}, callback);
+    self.constructor.findOne({ _id: self.parentId }, callback);
   });
 
   // Returns the list of ancestors + current node
-  schema.method('selfAndAncestors', function(callback) {
+  schema.method('selfAndAncestors', function(filters, fields, options, callback) {
     var self = this;
-    self.constructor.where('lft').lte(self.lft).where('rgt').gte(self.rgt).exec(callback);
+    if ('function' === typeof filters) {
+        callback = filters;
+        filters = {};
+    }
+    else if ('function' === typeof fields) {
+        callback = fields;
+        fields = null;
+    }
+    else if ('function' === typeof options) {
+        callback = options;
+        options = {};
+    }
+
+    filters = filters || {};
+    fields = fields || null;
+    options = options || {};
+
+    if(filters['$query']){
+        filters['$query']['lft'] = { $lte: self.lft };
+        filters['$query']['rgt'] = { $gte: self.rgt };
+    } else {
+        filters['lft'] = { $lte: self.lft };
+        filters['rgt'] = { $gte: self.rgt };
+    }
+    self.constructor.find(filters, fields, options, callback);
   });
 
   // Returns the list of ancestors
-  schema.method('ancestors', function(callback) {
+  schema.method('ancestors', function(filters, fields, options, callback) {
     var self = this;
-    self.selfAndAncestors(function(err, nodes) {
-      if (err) {
-        callback(err, null);
-      } else {
-        var nodesMinusSelf = nodes.filter(function(node) { return self._id.toString() !== node._id.toString(); });
-        callback(null, nodesMinusSelf);
-      }
-    });
+    if ('function' === typeof filters) {
+        callback = filters;
+        filters = {};
+    }
+    else if ('function' === typeof fields) {
+        callback = fields;
+        fields = null;
+    }
+    else if ('function' === typeof options) {
+        callback = options;
+        options = {};
+    }
+
+    filters = filters || {};
+    fields = fields || null;
+    options = options || {};
+
+    if(filters['$query']){
+        filters['$query']['lft'] = { $lt: self.lft };
+        filters['$query']['rgt'] = { $gt: self.rgt };
+    } else {
+        filters['lft'] = { $lt: self.lft };
+        filters['rgt'] = { $gt: self.rgt };
+    }
+    self.constructor.find(filters, fields, options, callback);
   });
 
   // Returns the list of children
-  schema.method('children', function(callback) {
-    var self = this;
-    self.constructor.find({parentId: self._id}, callback);
+  schema.method('children', function(filters, fields, options, callback) {
+      var self = this;
+      if ('function' === typeof filters) {
+          callback = filters;
+          filters = {};
+      }
+      else if ('function' === typeof fields) {
+          callback = fields;
+          fields = null;
+      }
+      else if ('function' === typeof options) {
+          callback = options;
+          options = {};
+      }
+
+      filters = filters || {};
+      fields = fields || null;
+      options = options || {};
+
+      if(filters['$query']){
+          filters['$query']['parentId'] = self._id;
+      } else {
+          filters['parentId'] = self._id;
+      }
+      self.constructor.find(filters, fields, options, callback);
   });
 
   // Returns the list of children + current node
-  schema.method('selfAndChildren', function(callback) {
+  schema.method('selfAndChildren',function(filters, fields, options, callback) {
     var self = this;
-    self.children(function(err, nodes) {
-      if (err) {
-        callback(err, null);
-      } else {
-        callback(null, nodes.concat([self]));
+      if ('function' === typeof filters) {
+          callback = filters;
+          filters = {};
       }
-    });
+      else if ('function' === typeof fields) {
+          callback = fields;
+          fields = null;
+      }
+      else if ('function' === typeof options) {
+          callback = options;
+          options = {};
+      }
+
+      filters = filters || {};
+      fields = fields || null;
+      options = options || {};
+
+      if(filters['$query']){
+          filters['$query']['$or'] = [{ parentId: self._id }, {_id: self._id }] ;
+      } else {
+          filters['$or'] = [{ parentId: self._id }, {_id: self._id }];
+      }
+      self.constructor.find(filters, fields, options, callback);
   });
 
   // Returns the list of descendants + current node
-  schema.method('selfAndDescendants', function(callback) {
+  schema.method('selfAndDescendants', function(filters, fields, options, callback) {
     var self = this;
-    self.constructor.where('lft').gte(self.lft).where('rgt').lte(self.rgt).exec(callback);
+    if ('function' === typeof filters) {
+        callback = filters;
+        filters = {};
+    }
+    else if ('function' === typeof fields) {
+        callback = fields;
+        fields = null;
+    }
+    else if ('function' === typeof options) {
+        callback = options;
+        options = {};
+    }
+
+    filters = filters || {};
+    fields = fields || null;
+    options = options || {};
+
+    if(filters['$query']){
+        filters['$query']['lft'] = { $gte: self.lft };
+        filters['$query']['rgt'] = { $lte: self.rgt };
+    } else {
+        filters['lft'] = { $gte: self.lft };
+        filters['rgt'] = { $lte: self.rgt };
+    }
+    self.constructor.find(filters, fields, options, callback);
   });
 
   // Returns the list of descendants
-  schema.method('descendants', function(callback) {
+  schema.method('descendants', function(filters, fields, options, callback) {
     var self = this;
-    self.selfAndDescendants(function(err, nodes) {
-      if (err) {
-        callback(err, null);
-      } else {
-        var nodesMinusSelf = nodes.filter(function(node) { return self._id.toString() !== node._id.toString(); });
-        callback(null, nodesMinusSelf);
-      }
-    });
+    if ('function' === typeof filters) {
+        callback = filters;
+        filters = {};
+    }
+    else if ('function' === typeof fields) {
+        callback = fields;
+        fields = null;
+    }
+    else if ('function' === typeof options) {
+        callback = options;
+        options = {};
+    }
+
+    filters = filters || {};
+    fields = fields || null;
+    options = options || {};
+
+    if(filters['$query']){
+        filters['$query']['lft'] = { $gt: self.lft };
+        filters['$query']['rgt'] = { $lt: self.rgt };
+    } else {
+        filters['lft'] = { $gt: self.lft };
+        filters['rgt'] = { $lt: self.rgt };
+    }
+    self.constructor.find(filters, fields, options, callback);
   });
 
   // Returns the list of all nodes with the same parent + current node
-  schema.method('selfAndSiblings', function(callback) {
-    var self = this;
-    self.constructor.find({parentId: self.parentId}, callback);
+  schema.method('selfAndSiblings', function(filters, fields, options, callback) {
+      var self = this;
+      if ('function' === typeof filters) {
+          callback = filters;
+          filters = {};
+      }
+      else if ('function' === typeof fields) {
+          callback = fields;
+          fields = null;
+      }
+      else if ('function' === typeof options) {
+          callback = options;
+          options = {};
+      }
+
+      filters = filters || {};
+      fields = fields || null;
+      options = options || {};
+
+      if(filters['$query']){
+          filters['$query']['parentId'] = self.parentId;
+      } else {
+          filters['parentId'] = self.parentId;
+      }
+      self.constructor.find(filters, fields, options, callback);
   });
 
   // Returns the list of all nodes with the same parent
-  schema.method('siblings', function(callback) {
+  schema.method('siblings', function(filters, fields, options, callback) {
     var self = this;
-    self.selfAndSiblings(function(err, nodes) {
-      if (err) {
-        callback(err, null);
-      } else {
-        var nodesMinusSelf = nodes.filter(function(node) { return self._id.toString() !== node._id.toString(); });
-        callback(null, nodesMinusSelf);
-      }
-    });
+    if ('function' === typeof filters) {
+        callback = filters;
+        filters = {};
+    }
+    else if ('function' === typeof fields) {
+        callback = fields;
+        fields = null;
+    }
+    else if ('function' === typeof options) {
+        callback = options;
+        options = {};
+    }
+
+    filters = filters || {};
+    fields = fields || null;
+    options = options || {};
+
+    if(filters['$query']){
+        filters['$query']['parentId'] = self.parentId;
+        filters['$query']['_id'] = { $ne: self._id } ;
+    } else {
+        filters['parentId'] = self.parentId;
+        filters['_id'] = { $ne: self._id } ;
+    }
+    self.constructor.find(filters, fields, options, callback);
   });
 
   // Returns the level of this object in the tree. Root level is 0

--- a/tests/nested_set_test.js
+++ b/tests/nested_set_test.js
@@ -232,9 +232,7 @@ var tests = testCase({
         User.findOne({username: 'michael'}, function(err, michael) {
           michael.selfAndChildren(function(err, people) {
             test.ok(!err);
-            test.deepEqual(
-              ['angela', 'jim', 'meredith', 'michael'],
-              people.map(function(p) {return p.username; }).sort());
+            test.deepEqual(['angela', 'jim', 'meredith', 'michael'], people.map(function(p) {return p.username; }).sort());
             test.done();
           });
         });


### PR DESCRIPTION
I wanted to try and move to a nested set approach.  I am currently using a materialized path approach but will soon be bumping up agains the max index fields size in mongo.  This approach would allow me to store a tree with greater depth but after adding all the mogoose signatures a test in our system has revealed the inserts are just too slow for our needs.  The reads are awesome but we need to write 1M nodes and the amount of thrashing that occurs is very high.  At any rate, this patch adds mongoose signatures to all your methods so that users can pass in filters, fields, options, and a callback into all of your tree methods.