### PR TITLE
treeLength method

### DIFF
--- a/lib/nested_set.js
+++ b/lib/nested_set.js
@@ -412,6 +412,26 @@ var NestedSetPlugin = function(schema, options) {
       callback(err, nodes.length);
     });
   });
+
+  // Returns the length of the subtree under this object
+  schema.method('treeLength', function(callback) {
+    var self = this;
+    self.selfAndDescendants(function(err, nodes) {
+      var levels = [];
+      nodes.forEach(function (node) {
+        node.level(function (err, value) {
+          levels.push(value);
+          if (levels.length == nodes.length) {
+            var min = levels[0];
+            var max = Math.max.apply(null, levels);
+            var length = (max - min) + 1; 
+            callback(err, length);
+          }
+        });   
+      });
+    });
+  });
+
 };
 
 module.exports = exports = NestedSetPlugin;


### PR DESCRIPTION
For a project where I am using mongoose nested set, I needed to write a method for finding the height/length of a sub tree under a node. So I thought it would be nice if I can add this feature into mongoose nested set. 